### PR TITLE
SERCOMx support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: python -m pip install -r tools/requirements.txt
+
       - name: Configure
         run: cmake --preset=armgcc-debug-unix .
 
       - name: Build
         run: cmake --build --preset=build-app-armgcc-debug-unix
 
-      # TODO: archive build
       - name: Archive documentation
         uses: actions/upload-artifact@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ option(SAMD21_LINE_BL_BUILD_TESTS "Enables library test cases" OFF)
 find_package(Python REQUIRED)
 
 include(tools/cmake/CPM.cmake)
-CPMAddPackage("gh:c4deszes/samd21-hal#feature/tcc-improvements")
-CPMAddPackage("gh:c4deszes/bike-flash-tool#master")
+CPMAddPackage("gh:c4deszes/samd21-hal@0.2.0")
+CPMAddPackage("gh:c4deszes/bike-flash-tool@0.1.0")
 
 # Documentation
 #add_subdirectory(docs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,14 +4,14 @@ project(
     samd21-line-bootloader
     DESCRIPTION "Bootloader for SAMD21 devices over LINE protocol"
     LANGUAGES C CXX ASM
-    VERSION 0.1.0)
+    VERSION 0.2.0)
 
 option(SAMD21_LINE_BL_BUILD_TESTS "Enables library test cases" OFF)
 
 find_package(Python REQUIRED)
 
 include(tools/cmake/CPM.cmake)
-CPMAddPackage("gh:c4deszes/samd21-hal#master")
+CPMAddPackage("gh:c4deszes/samd21-hal#feature/tcc-improvements")
 CPMAddPackage("gh:c4deszes/bike-flash-tool#master")
 
 # Documentation

--- a/src/boot.c
+++ b/src/boot.c
@@ -71,6 +71,7 @@ void _fatal() {
 }
 
 void BOOT_Initialize(void) {
+    // TODO: replace with HAL api call
     NVMCTRL_REGS->NVMCTRL_CTRLB = NVMCTRL_CTRLB_RWS_HALF;
     //NVMCTRL_SetReadWaitStates(NVMCTRL_CTRLB_RWS_HALF_Val);
 

--- a/src/comm.c
+++ b/src/comm.c
@@ -135,6 +135,23 @@ void COMM_Initialize(void) {
     FLASH_LINE_Init(FLASH_LINE_BOOTLOADER_MODE);
 }
 
+
+void SERCOM0_Interrupt(void) {
+    SERCOM_USART_InterruptHandler(SERCOM0);
+}
+
+void SERCOM1_Interrupt(void) {
+    SERCOM_USART_InterruptHandler(SERCOM1);
+}
+
+void SERCOM2_Interrupt(void) {
+    SERCOM_USART_InterruptHandler(SERCOM2);
+}
+
+void SERCOM3_Interrupt(void) {
+    SERCOM_USART_InterruptHandler(SERCOM3);
+}
+
 void COMM_Update(void) {
     uint8_t length = SERCOM_USART_Available(comm_sercom);
     while (length > 0) {

--- a/src/init.c
+++ b/src/init.c
@@ -14,6 +14,7 @@
 
 #include "common/scheduler.h"
 
+// TODO: remove this once direct register access is removed
 #include "atsamd21e18a.h"
 
 void Initialize(void) {
@@ -22,11 +23,8 @@ void Initialize(void) {
     //WDT_InitializeNormal(&wdt_config);
     BOOT_Initialize();
 
-    // TODO: likely not needed, also comes at a performance penalty
-    //NVMCTRL_REGS->NVMCTRL_CTRLB |= NVMCTRL_CTRLB_CACHEDIS_Msk;
     NVMCTRL_SetAutoPageWrite(false);
-    
-    // TODO: these should not be called, according to docs these are by default enabled on POR?
+
     SYSCTRL_EnableInternalOSC32K();
     GCLK_Reset();
     SYSCTRL_ConfigureOSC8M();
@@ -41,15 +39,18 @@ void Initialize(void) {
     SCH_Init();
 
     GCLK_SelectGenerator(GCLK_CLKCTRL_ID_TCC0_TCC1_Val, GCLK_GEN4);
+    // TODO: move this to HAL library
     PM_REGS->PM_APBCMASK |= PM_APBCMASK_TCC0_Msk;
     TCC_Reset(TCC0);
     TCC_SetupTrigger(TCC0, 1000);   // 1000us = 1ms period
     TCC_Enable(TCC0);
 
-    // Enable interrupts
     NVIC_Initialize();
 }
 
 void TCC0_Interrupt(void) {
     SCH_Trigger();
 }
+
+// TODO: handle hardfault, sysfault
+// dummy handlers should set boot_state to error

--- a/src/tasks.c
+++ b/src/tasks.c
@@ -10,5 +10,6 @@ void SCH_Task1ms(void) {
 }
 
 void SCH_Task10ms_A(void) {
+    // TODO: enable watchdog
     // WDT_Acknowledge();
 }

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,1 @@
+intelhex


### PR DESCRIPTION
## Brief

- Previous HAL library versions don't support USART communication over all SERCOM peripherals due to the lack of interrupt handlers